### PR TITLE
Add dependency to the main test-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,10 @@
   <description>Example extension provided for demonstration purposes</description>
   <url>http://openrefine.org/</url>
 
+  <properties>
+    <openrefine.version>3.8.1</openrefine.version>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -73,7 +77,7 @@
      <dependency>
       <groupId>org.openrefine</groupId>
       <artifactId>main</artifactId>
-      <version>3.8.1</version>
+      <version>${openrefine.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -83,7 +87,7 @@
       <scope>provided</scope>
     </dependency>
 
-   <!-- add here the dependencies of your extension -->
+    <!-- add here the dependencies of your extension -->
 
     <dependency>
       <groupId>org.testng</groupId>
@@ -91,7 +95,13 @@
       <version>7.10.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openrefine</groupId>
+      <artifactId>main</artifactId>
+      <version>${openrefine.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-
 </project>
 

--- a/src/test/java/com/google/refine/sampleExtension/SampleUtilTest.java
+++ b/src/test/java/com/google/refine/sampleExtension/SampleUtilTest.java
@@ -3,12 +3,23 @@ package com.google.refine.sampleExtension;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
-import org.testng.annotations.Test;
+import java.io.Serializable;
 
-public class SampleUtilTest {
+import org.testng.annotations.Test;
+import com.google.refine.RefineTest;
+import com.google.refine.model.Project;
+
+public class SampleUtilTest extends RefineTest {
     
     @Test
     public void testStringArrayLength() {
+        // you can use the same sort of test utilities as in OpenRefine's own test suite
+        Project project = createProject(new String[] { "first column", "second column" },
+                new Serializable[][] {
+                  { "a", "b" },
+                  { "c", 3 }
+        });
+
         String[] myArray = new String[] { "foo", "bar" };
         
         assertEquals(SampleUtil.stringArrayLength(myArray), 2);


### PR DESCRIPTION
This demonstrates how extensions can currently re-use test utilities from OpenRefine's own Java test suite.
A real world usage is in [refine-wikitable-utils](https://github.com/wetneb/refine-wikitable-utils).