### PR TITLE
Link to extension and proposed file with requirements

### DIFF
--- a/GeneralRelease.md
+++ b/GeneralRelease.md
@@ -1,0 +1,11 @@
+* Link to the repository: 
+* License: 
+* Link to forum threads discussing the extension:
+* Description of the extension: input, expected behavior, output
+* Compatible OpenRefine version:
+* Commitment statement:
+* Maintenance statement:
+* Contact Method:
+* AI statement:
+* Estimated end-of-life date for the extension:
+* Community achievements:

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ This repository contains a scaffold of an OpenRefine extension, which you can us
 See [our guide to writing extensions](https://openrefine.org/docs/technical-reference/writing-extensions) for more information about the process.
 
 ### Getting started
+Make sure to familiarize yourself with [our extension developer guidelines](https://openrefine.org/docs/technical-reference/extension-dev-guidelines).
 
-To start your own extension, click the "Use this template" button in the top right corner of this page.
+To start your own extension from this template, click the "Use this template" button in the top right corner of this page.
 This will create a copy of this repository, where you can then change:
 * The extension name and description in `module/MOD-INF/module.properties`
 * The `groupId`, `artifactId`, `name` and `description` fields in `pom.xml`
 * Edit this `README.md` file to describe your extension to potential users and contributors instead of the sample extension's own instructions
 
+### General Release 
+
+Please ensure that your repository contains the general release file with the relevant information.


### PR DESCRIPTION
The current version assumes that the contributor has read the playbook. I added a link to the playbook instead of only providing a link to the writing guide. 

I'm also proposing a separate file for the general release requirements so we can eventually easily parse an existing file instead of scanning through the whole repository (in most cases). We could even add that to the playbook (i.e. Please ensure that your repository contains _a file named GeneralRelease.md_ with  the following information for your extension to be added to the OpenRefine [extension directory](https://openrefine.org/extensions))